### PR TITLE
Added missing s

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Getting the master key isn't that hard
 
 - Your key should be outputted.
 
-Note: **Do not share this mater key with anyone.**
+Note: **Do not share this master key with anyone.**
 
 # Examples
 See all examples in the examples folder

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import asyncio
 
 
 async def main():
-    client = tixte.Client('your-mater-key')
+    client = tixte.Client('your-master-key')
     file = tixte.File('this_image.png')
     
     uploaded_file = await client.upload_file(file=file)  # Upload file


### PR DESCRIPTION
In line 27 a `s` was missing from master.
By the way, the same error is in the PyPI readme.